### PR TITLE
Add notice comment to formatted code blocks

### DIFF
--- a/__snapshots__/format-comment.test.js.snap
+++ b/__snapshots__/format-comment.test.js.snap
@@ -1,27 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Formats a code block 1`] = `
-"\`\`\`js
+"<!-- The following code block was formatted with \`prettier\`. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
+Learn more about \`prettier-github\` at https://github.com/jgierer12/prettier-github
+
+foo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());
+
+-->
+\`\`\`js
 foo(
   reallyLongArg(),
   omgSoManyParameters(),
   IShouldRefactorThis(),
   isThereSeriouslyAnotherOne()
 );
-\`\`\`
-"
+\`\`\`"
 `;
 
 exports[`Formats multiple code blocks 1`] = `
-"\`\`\`js
-foo(
-  reallyLongArg(),
-  omgSoManyParameters(),
-  IShouldRefactorThis(),
-  isThereSeriouslyAnotherOne()
-);
-\`\`\`
+"<!-- The following code block was formatted with \`prettier\`. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
+Learn more about \`prettier-github\` at https://github.com/jgierer12/prettier-github
 
+foo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());
+
+-->
 \`\`\`js
 foo(
   reallyLongArg(),
@@ -30,5 +32,18 @@ foo(
   isThereSeriouslyAnotherOne()
 );
 \`\`\`
-"
+<!-- The following code block was formatted with \`prettier\`. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
+Learn more about \`prettier-github\` at https://github.com/jgierer12/prettier-github
+
+foo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());
+
+-->
+\`\`\`js
+foo(
+  reallyLongArg(),
+  omgSoManyParameters(),
+  IShouldRefactorThis(),
+  isThereSeriouslyAnotherOne()
+);
+\`\`\`"
 `;

--- a/__snapshots__/format-comment.test.js.snap
+++ b/__snapshots__/format-comment.test.js.snap
@@ -47,3 +47,15 @@ foo(
 );
 \`\`\`"
 `;
+
+exports[`Overrides notice if the comment has been formatted previously 1`] = `
+"<!-- The following code block was formatted with \`prettier\`. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
+Learn more about \`prettier-github\` at https://github.com/jgierer12/prettier-github
+
+bar()
+
+-->
+\`\`\`js
+bar();
+\`\`\`"
+`;

--- a/format-comment.js
+++ b/format-comment.js
@@ -1,6 +1,14 @@
 const extract = require('extract-gfm');
 const prettier = require('prettier');
 
+const noticeComment = originalCode =>
+`<!-- The following code block was formatted with \`prettier\`. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
+Learn more about \`prettier-github\` at https://github.com/jgierer12/prettier-github
+
+${originalCode}
+
+-->`;
+
 module.exports = commentRaw => {
 	const comment = extract.parseBlocks(commentRaw);
 
@@ -15,15 +23,9 @@ module.exports = commentRaw => {
 			try {
 				const formattedCode = format(block.code);
 				if (formattedCode !== block.code) {
-					const newText =
-`<!-- The following code block was formatted with \`prettier\`. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
-Learn more about \`prettier-github\` at https://github.com/jgierer12/prettier-github
-
-${block.code}
-
--->
-${block.block.replace(block.code, formattedCode)}`;
-					comment.text = comment.text.replace(extract.id(i), newText);
+					const newText = noticeComment(block.code) + '\n' + block.block.replace(block.code, formattedCode);
+					const oldTextRegex = new RegExp(`(${noticeComment('[\\s\\S]*')}\n)?${extract.id(i)}`);
+					comment.text = comment.text.replace(oldTextRegex, newText);
 					return;
 				}
 			} catch (error) {

--- a/format-comment.js
+++ b/format-comment.js
@@ -10,16 +10,29 @@ module.exports = commentRaw => {
 
 	const format = source => prettier.format(source, JSON.parse(process.env.PRETTIER_OPTIONS || '{}')).replace(/\n$/, '');
 
-	comment.blocks.map(block => {
+	comment.blocks.forEach((block, i) => {
 		if (JSON.parse(process.env.LANGS || '["js", "javascript", "jsx", "es6", "css", "less", "scss", "ts"]').includes(block.lang)) {
 			try {
-				block.code = format(block.code);
+				const formattedCode = format(block.code);
+				if (formattedCode !== block.code) {
+					const newText =
+`<!-- The following code block was formatted with \`prettier\`. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
+Learn more about \`prettier-github\` at https://github.com/jgierer12/prettier-github
+
+${block.code}
+
+-->
+${block.block.replace(block.code, formattedCode)}`;
+					comment.text = comment.text.replace(extract.id(i), newText);
+					return;
+				}
 			} catch (error) {
 				console.warn('Error while formatting code block:', error.message);
 			}
 		}
-		return block;
+
+		comment.text = comment.text.replace(extract.id(i), block.block);
 	});
 
-	return extract.injectBlocks(comment.text, comment.blocks);
+	return comment.text;
 };

--- a/format-comment.js
+++ b/format-comment.js
@@ -24,7 +24,8 @@ module.exports = commentRaw => {
 				const formattedCode = format(block.code);
 				if (formattedCode !== block.code) {
 					const newText = noticeComment(block.code) + '\n' + block.block.replace(block.code, formattedCode);
-					const oldTextRegex = new RegExp(`(${noticeComment('[\\s\\S]*')}\n)?${extract.id(i)}`);
+					const noticeCommentRegex = noticeComment('__OLD_BLOCK__').replace(/([.*+?^=!:${}()|[\]/\\])/g, '\\$1');
+					const oldTextRegex = new RegExp(`(${noticeCommentRegex.replace('__OLD_BLOCK__', '[\\s\\S]*')}\n)?${extract.id(i)}`.replace(/\n/g, '(\n|(\r\n))'));
 					comment.text = comment.text.replace(oldTextRegex, newText);
 					return;
 				}

--- a/format-comment.test.js
+++ b/format-comment.test.js
@@ -12,6 +12,12 @@ test('Formats multiple code blocks', () => {
 	expect(formatComment(comment)).toMatchSnapshot();
 });
 
+test('Overrides notice if the comment has been formatted previously', () => {
+	const comment = '<!-- The following code block was formatted with `prettier`. If this is not desired, please change this comment to `prettier-github disable`. A copy of your original code block is included below in case you want to restore it.\nLearn more about `prettier-github` at https://github.com/jgierer12/prettier-github\n\nfoo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());\n\n-->\n```js\nbar()\n```';
+
+	expect(formatComment(comment)).toMatchSnapshot();
+});
+
 test('Ignores no code blocks', () => {
 	const comment = 'Nothing to format here\n';
 

--- a/format-comment.test.js
+++ b/format-comment.test.js
@@ -1,13 +1,13 @@
 const formatComment = require('./format-comment.js');
 
 test('Formats a code block', () => {
-	const comment = '```js\nfoo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());\n```\n';
+	const comment = '```js\nfoo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());\n```';
 
 	expect(formatComment(comment)).toMatchSnapshot();
 });
 
 test('Formats multiple code blocks', () => {
-	const comment = '```js\nfoo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());\n```\n\n```js\nfoo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());\n```\n';
+	const comment = '```js\nfoo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());\n```\n```js\nfoo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());\n```';
 
 	expect(formatComment(comment)).toMatchSnapshot();
 });
@@ -19,19 +19,19 @@ test('Ignores no code blocks', () => {
 });
 
 test('Ignores incompatible code blocks', () => {
-	const comment = '```sh\necho "Nothing to format here"\n```\n';
+	const comment = '```sh\necho "Nothing to format here"\n```';
 
 	expect(formatComment(comment)).toBe(comment);
 });
 
 test('Ignores correctly formatted code blocks', () => {
-	const comment = '```js\nconst all = "good";\n```\n';
+	const comment = '```js\nconst all = "good";\n```';
 
 	expect(formatComment(comment)).toBe(comment);
 });
 
 test('Ignores comments containing `<!-- prettier-github disable -->`', () => {
-	const comment = '<!-- prettier-github disable -->\n\n```js\nfoo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());\n```\n';
+	const comment = '<!-- prettier-github disable -->\n\n```js\nfoo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());\n```';
 
 	expect(formatComment(comment)).toBe(comment);
 });
@@ -44,14 +44,14 @@ describe('invalid code blocks', () => {
 	});
 
 	test('Warns about invalid code blocks', () => {
-		const comment = '```js\ninvalid javascript\n```\n';
+		const comment = '```js\ninvalid javascript\n```';
 		formatComment(comment);
 
 		expect(global.console.warn).toHaveBeenCalled();
 	});
 
 	test('Ignores invalid code blocks', () => {
-		const comment = '```js\ninvalid javascript\n```\n';
+		const comment = '```js\ninvalid javascript\n```';
 
 		expect(formatComment(comment)).toBe(comment);
 	});


### PR DESCRIPTION
<!-- prettier-github disable -->
If `prettier-github` formats a code block, this will be noted in a comment, including instructions to disable the bot and the original code block.

For example, this:
````markdown
```js
foo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());
```
````
will now be transformed into this:
````markdown
<!-- The following code block was formatted with `prettier`. If this is not desired, please change this comment to `prettier-github disable`. A copy of your original code block is included below in case you want to restore it.
Learn more about `prettier-github` at https://github.com/jgierer12/prettier-github

foo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());

-->
```js
foo(
  reallyLongArg(),
  omgSoManyParameters(),
  IShouldRefactorThis(),
  isThereSeriouslyAnotherOne()
);
```
````

Closes #3 
@k15a does this look good?