### PR TITLE
Fix update comment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
   - "node"
-  - "6"
+  - "7"

--- a/handle-comment.js
+++ b/handle-comment.js
@@ -1,25 +1,48 @@
 const GitHubApi = require('github');
 const formatComment = require('./format-comment.js');
 
-module.exports = data => {
-	if (!['created', 'edited'].includes(data.action)) {
-		return;
+module.exports = async data => {
+	const github = new GitHubApi(JSON.parse(process.env.GITHUB_OPTIONS || '{}'));
+	const repo = {
+		owner: data.repository.owner.login,
+		repo: data.repository.name
+	};
+
+	switch (data.action) {
+		case 'created':
+			break;
+
+		case 'edited':
+			try {
+				const updatedComment = await github.issues.getComment(
+					Object.assign({
+						id: data.comment.id
+					}, repo)
+				);
+				data.comment = updatedComment.data;
+				break;
+			} catch (error) {
+				console.warn('Error fetching updated comment:', error);
+				return;
+			}
+
+		default:
+			return;
 	}
 
 	const newComment = formatComment(data.comment.body);
 
 	if (newComment !== data.comment.body) {
-		const github = new GitHubApi(JSON.parse(process.env.GITHUB_OPTIONS || '{}'));
 		github.authenticate({
 			type: 'oauth',
 			token: process.env.GITHUB_TOKEN
 		});
 
-		github.issues.editComment({
-			owner: data.repository.owner.login,
-			repo: data.repository.name,
-			id: data.comment.id,
-			body: newComment
-		});
+		github.issues.editComment(
+			Object.assign({
+				id: data.comment.id,
+				body: newComment
+			}, repo)
+		);
 	}
 };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Format code in GitHub comments with `prettier`",
   "license": "MIT",
   "repository": "jgierer12/prettier-github",
+  "engines": {
+    "node": ">=7"
+  },
   "author": {
     "name": "Jonas Gierer",
     "email": "jgierer12@outlook.com",

--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ const captureRaw = (req, res, buffer) => {
 
 app.use(bodyParser.json({verify: captureRaw}));
 
-app.post('/', (req, res) => {
+app.post('/', async (req, res) => {
 	const event = req.headers['x-github-event'];
 
 	if (!event) {
@@ -29,7 +29,7 @@ app.post('/', (req, res) => {
 	}
 
 	if (event === 'issue_comment') {
-		handleComment(req.body);
+		await handleComment(req.body);
 	}
 
 	res.end();


### PR DESCRIPTION
Since GitHub sometimes sends the old version of an edited comment, we should fetch it
again to ensure we're working on the newest version of the comment.

This will require `node >= 7` to enable `async`/`await` support