### PR TITLE
Support CSS, TypeScript, GraphQL and JSON languages

### DIFF
--- a/__snapshots__/format-comment.test.js.snap
+++ b/__snapshots__/format-comment.test.js.snap
@@ -1,22 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Formats a code block 1`] = `
-"<!-- The following code block was formatted with Prettier. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
-Learn more about Prettier GitHub at https://github.com/jgierer12/prettier-github
-
-foo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());
-
--->
-\`\`\`js
-foo(
-  reallyLongArg(),
-  omgSoManyParameters(),
-  IShouldRefactorThis(),
-  isThereSeriouslyAnotherOne()
-);
-\`\`\`"
-`;
-
 exports[`Formats multiple code blocks 1`] = `
 "<!-- The following code block was formatted with Prettier. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
 Learn more about Prettier GitHub at https://github.com/jgierer12/prettier-github
@@ -63,5 +46,78 @@ bar()
 -->
 \`\`\`js
 bar();
+\`\`\`"
+`;
+
+exports[`languages Formats a CSS code block 1`] = `
+"<!-- The following code block was formatted with Prettier. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
+Learn more about Prettier GitHub at https://github.com/jgierer12/prettier-github
+
+.foo {color: red;}
+
+-->
+\`\`\`css
+.foo {
+  color: red;
+}
+\`\`\`"
+`;
+
+exports[`languages Formats a GraphQL code block 1`] = `
+"<!-- The following code block was formatted with Prettier. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
+Learn more about Prettier GitHub at https://github.com/jgierer12/prettier-github
+
+{language(name: \\"GraphQL\\") {isSupported}}
+
+-->
+\`\`\`graphql
+{
+  language(name: \\"GraphQL\\") {
+    isSupported
+  }
+}
+\`\`\`"
+`;
+
+exports[`languages Formats a JSON code block 1`] = `
+"<!-- The following code block was formatted with Prettier. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
+Learn more about Prettier GitHub at https://github.com/jgierer12/prettier-github
+
+{\\"supportJSON\\": true}
+
+-->
+\`\`\`json
+{ \\"supportJSON\\": true }
+\`\`\`"
+`;
+
+exports[`languages Formats a JavaScript code block 1`] = `
+"<!-- The following code block was formatted with Prettier. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
+Learn more about Prettier GitHub at https://github.com/jgierer12/prettier-github
+
+foo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());
+
+-->
+\`\`\`js
+foo(
+  reallyLongArg(),
+  omgSoManyParameters(),
+  IShouldRefactorThis(),
+  isThereSeriouslyAnotherOne()
+);
+\`\`\`"
+`;
+
+exports[`languages Formats a TypeScript code block 1`] = `
+"<!-- The following code block was formatted with Prettier. If this is not desired, please change this comment to \`prettier-github disable\`. A copy of your original code block is included below in case you want to restore it.
+Learn more about Prettier GitHub at https://github.com/jgierer12/prettier-github
+
+interface ITypeScript {supported: boolean}
+
+-->
+\`\`\`ts
+interface ITypeScript {
+  supported: boolean;
+}
 \`\`\`"
 `;

--- a/format-comment.js
+++ b/format-comment.js
@@ -16,14 +16,14 @@ module.exports = (commentRaw, prettierConfig = {}) => {
 		return commentRaw;
 	}
 
-	const format = source => prettier.format(source, prettierConfig).replace(/\n$/, '');
+	const format = (source, lang) => prettier.format(source, Object.assign({filepath: `.${lang}`}, prettierConfig)).replace(/\n$/, '');
 
-	const langs = prettierConfig.langs || ['js', 'javascript', 'jsx', 'es6', 'css', 'less', 'scss', 'ts'];
+	const langs = prettierConfig.langs || ['js', 'javascript', 'jsx', 'es6', 'css', 'less', 'scss', 'ts', 'graphql', 'json'];
 
 	comment.blocks.forEach((block, i) => {
 		if (langs.includes(block.lang)) {
 			try {
-				const formattedCode = format(block.code);
+				const formattedCode = format(block.code, block.lang);
 				if (formattedCode !== block.code) {
 					const newText = noticeComment(block.code) + '\n' + block.block.replace(block.code, formattedCode);
 					const noticeCommentRegex = noticeComment('__OLD_BLOCK__').replace(/([.*+?^=!:${}()|[\]/\\])/g, '\\$1');

--- a/format-comment.test.js
+++ b/format-comment.test.js
@@ -1,9 +1,35 @@
 const formatComment = require('./format-comment.js');
 
-test('Formats a code block', () => {
-	const comment = '```js\nfoo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());\n```';
+describe('languages', () => {
+	test('Formats a JavaScript code block', () => {
+		const comment = '```js\nfoo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne());\n```';
 
-	expect(formatComment(comment)).toMatchSnapshot();
+		expect(formatComment(comment)).toMatchSnapshot();
+	});
+
+	test('Formats a CSS code block', () => {
+		const comment = '```css\n.foo {color: red;}\n```';
+
+		expect(formatComment(comment)).toMatchSnapshot();
+	});
+
+	test('Formats a TypeScript code block', () => {
+		const comment = '```ts\ninterface ITypeScript {supported: boolean}\n```';
+
+		expect(formatComment(comment)).toMatchSnapshot();
+	});
+
+	test('Formats a JSON code block', () => {
+		const comment = '```json\n{"supportJSON": true}\n```';
+
+		expect(formatComment(comment)).toMatchSnapshot();
+	});
+
+	test('Formats a GraphQL code block', () => {
+		const comment = '```graphql\n{language(name: "GraphQL") {isSupported}}\n```';
+
+		expect(formatComment(comment)).toMatchSnapshot();
+	});
 });
 
 test('Formats multiple code blocks', () => {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"extract-gfm": "^0.1.0",
 		"github": "^9.2.0",
 		"jsonwebtoken": "^7.4.1",
-		"prettier": "^1.4.2"
+		"prettier": "^1.5.2"
 	},
 	"devDependencies": {
 		"eslint": "^3.19.0",


### PR DESCRIPTION
With [version 1.5.0](https://github.com/prettier/prettier/releases/tag/1.5.0), Prettier introduced GraphQL and JSON formatting.
This PR will add support for all languages currently supported by Prettier, including
CSS, TypeScript, GraphQL and JSON.